### PR TITLE
Remove duplicate `utils` from list

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,7 @@ Follow these guidelines when implementing structure presented in [Project Struct
         └── pages
             └── Main
                 ├── utils
-                │   └── utils
-                │       └── findUser.js
+                │   └── findUser.js
                 ├── index.js
                 ├── test.js
                 └── style.sass


### PR DESCRIPTION
Is this a typo or is it suppose to be like that?